### PR TITLE
chore: remove deprecated reference to osx-cli github

### DIFF
--- a/src/data/DevTools.tsx
+++ b/src/data/DevTools.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {IWelcomeCardProps} from '../components/WelcomeCard';
-import {RocketIcon, PageIcon, InfoIcon} from '../components';
+import {PageIcon, InfoIcon} from '../components';
 
 const devTools: IWelcomeCardProps[] = [
   {
@@ -9,13 +9,6 @@ const devTools: IWelcomeCardProps[] = [
     icon: <InfoIcon />,
     linkLabel: 'Get Started Tutorial',
     href: 'https://github.com/aragon/greeter-plugin-tutorial',
-  },
-  {
-    title: 'CLI',
-    description: 'A CLI to speed up your plugin development lifecycle.',
-    icon: <RocketIcon />,
-    linkLabel: 'Dev Tool',
-    href: 'https://github.com/aragon/cli',
   },
   {
     title: 'Upgradeable Plugin 101',


### PR DESCRIPTION
## Description

Remove osx-cli reference from the developer portal Get Started site https://devs.aragon.org/dev-tools/

(I didn't remove the RocketIcon component file as it's used somewhere else)

Task: [OS-1091](https://aragonassociation.atlassian.net/browse/OS-1091)



[OS-1091]: https://aragonassociation.atlassian.net/browse/OS-1091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ