### PR TITLE
fix: update outdated link for our Developer Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   •
   <a href="https://devs.aragon.org/">Developer Portal</a>
   •
-  <a href="https://aragonproject.typeform.com/to/LngekEhU">Join our Developer Community</a>
+  <a href="https://aragondevelopers.substack.com/">Join our Developer Community</a>
   •
   <a href="https://aragonproject.typeform.com/dx-contribution">Contribute</a>
 </p>
@@ -14,7 +14,7 @@
 
 # Aragon OSx Developer Portal
 
-Aragon's Developer Portal holds all documentation developers need to kickstart their journey building with the Aragon OSx stack. You can find it in production [here](https://devs.aragon.org). 
+Aragon's Developer Portal holds all documentation developers need to kickstart their journey building with the Aragon OSx stack. You can find it in production [here](https://devs.aragon.org).
 
 This website is built using [Docusaurus 3](https://docusaurus.io/), a static website generator for technical documentations.
 

--- a/docs/osx/02-how-to-guides/01-dao/03-protocol-upgrades.md
+++ b/docs/osx/02-how-to-guides/01-dao/03-protocol-upgrades.md
@@ -10,4 +10,4 @@ To make it easy for your DAO to switch to future Aragon OSx protocol versions, w
 
 Whenever we provide a new Aragon OSx protocol version, it will be possible to upgrade your DAO and associated plugins through your DAO dashboard.
 
-[Add your email here](https://aragonproject.typeform.com/to/LngekEhU) if you'd like to receive updates when this happens!
+[Add your email here](https://aragondevelopers.substack.com/) if you'd like to receive updates when this happens!

--- a/docs/subgraph/reference-guide/index.md
+++ b/docs/subgraph/reference-guide/index.md
@@ -5,4 +5,4 @@ sidebar_label: Reference Guide
 
 ## Subgraph
 
-This section contains the auto-generated documentation of the individual entities of our graphql.schema.
+This section contains the auto-generated documentation of the individual entities of our graphql schema.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,7 +17,7 @@ const config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   onBrokenAnchors: 'throw',
-  
+
   favicon: 'img/Aragon-logo-circle.png',
 
   presets: [
@@ -131,7 +131,7 @@ const config = {
       announcementBar: {
         id: 'register_to_dev_newsletter',
         content:
-          'Register to our developer newsletter and get the latest updates on DAO tooling <a target="_blank" rel="noopener noreferrer" href="https://aragonproject.typeform.com/to/LngekEhU">here</a></strong>!',
+          'Register to our developer newsletter and get the latest updates on DAO tooling <a target="_blank" rel="noopener noreferrer" href="https://aragondevelopers.substack.com/">here</a></strong>!',
         backgroundColor: '#3164fa',
         textColor: '#fff',
         isCloseable: true,

--- a/src/data/ComponentCards.tsx
+++ b/src/data/ComponentCards.tsx
@@ -22,14 +22,14 @@ const componentCards: IComponentCardProps[] = [
     img: <IllustrationSdk />,
     to: '/docs/sdk',
   },
-  {
-    title: 'Aragon Subgraph',
-    description:
-      'A powerful indexing and querying tool to get information from events emitted by the Aragon OSx contracts. The site is currently under development.',
-    img: <IllustrationSubgraph />,
-    to: '/docs/subgraph',
-    cta: 'Learn More (WiP)',
-  },
+  // {
+  //   title: 'Aragon Subgraph',
+  //   description:
+  //     'A powerful indexing and querying tool to get information from events emitted by the Aragon OSx contracts. The site is currently under development.',
+  //   img: <IllustrationSubgraph />,
+  //   to: '/docs/subgraph',
+  //   cta: 'Learn More (WiP)',
+  // },
   {
     title: 'Design System',
     description:

--- a/src/data/WelcomeCards.tsx
+++ b/src/data/WelcomeCards.tsx
@@ -25,7 +25,7 @@ const welcomeCards: IWelcomeCardProps[] = [
       'Keep up to date on the latest product releases and learn about working with Aragon',
     icon: <PageIcon />,
     linkLabel: 'Join here',
-    href: 'https://aragonproject.typeform.com/to/LngekEhU',
+    href: 'https://aragondevelopers.substack.com/',
   },
 ];
 


### PR DESCRIPTION
## Description

Replaced link redirecting to enroll to our Developer Community.
Hided subgraph docs from main page.

Task: [OS-1197](https://aragonassociation.atlassian.net/browse/OS-1197)


[OS-1197]: https://aragonassociation.atlassian.net/browse/OS-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ