### PR TITLE
Undo staging-temp and add docusaurus versions - Fleek - 1

### DIFF
--- a/.github/workflows/publish-on-fleek.yaml
+++ b/.github/workflows/publish-on-fleek.yaml
@@ -4,13 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       source_branch:
-        description: 'Publish content from branch (master|staging-temp)'
+        description: 'Publish content from branch (master|staging)'
         required: true
-        default: staging-temp
+        default: staging
         type: choice
         options:
           - master
-          - staging-temp
+          - staging
 
 jobs:
   build-and-deploy:
@@ -28,7 +28,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install and build
-        run: yarn && yarn build
+        run: yarn && yarn docs:subgraph && yarn optimize-svg && yarn build
 
       - name: Activate Fleek
         run: mv fleek_${{ inputs.source_branch }}.json .fleek.json

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+/docs/subgraph/reference-guide
 
 # Misc
 .DS_Store

--- a/fleek_master.json
+++ b/fleek_master.json
@@ -9,7 +9,7 @@
   "build": {
     "baseDir": "",
     "publicDir": "build/",
-    "command": "yarn && yarn build",
+    "command": "yarn && yarn docs:subgraph && yarn optimize-svg && yarn build",
     "rootDir": ""
   }
 }

--- a/fleek_staging.json
+++ b/fleek_staging.json
@@ -9,7 +9,7 @@
   "build": {
     "baseDir": "",
     "publicDir": "build/",
-    "command": "yarn && yarn build",
+    "command": "yarn && yarn docs:subgraph && yarn optimize-svg && yarn build",
     "rootDir": ""
   }
 }


### PR DESCRIPTION
## Description

1st Part of the process of reverting the current functioning of staging and staging-temp + adding versioning to our Docs.

In this PR the configuration for building our Fleek Website has been updated to include subgraph documentation.
That effectively removes the staging-temp utility. 

Task: [OS-1276](https://aragonassociation.atlassian.net/browse/OS-1276)


[OS-1276]: https://aragonassociation.atlassian.net/browse/OS-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ