### PR TITLE
feat: Restore landing page and customize navbar items (save point for new structure of 1.4)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,6 @@ const config = {
       '@docusaurus/preset-classic',
       {
         docs: {
-          routeBasePath: '/',
           sidebarPath: require.resolve('./sidebars.js'),
           remarkPlugins: [math],
           rehypePlugins: [katex],
@@ -114,51 +113,9 @@ const config = {
             'Aragon OSx enhances security and flexibility by isolating governance logic into modular plugins, making governance contracts safer and faster to customize.',
         },
       ],
-
       footer: {
+        // Costom footer is used (see: /theme/Footers)
         style: 'dark',
-        links: [
-          {
-            title: 'Docs',
-            items: [
-              {
-                label: 'Tutorial',
-                to: '/docs/intro',
-              },
-            ],
-          },
-          {
-            title: 'Community',
-            items: [
-              {
-                label: 'Stack Overflow',
-                href: 'https://ethereum.stackexchange.com/search?q=aragon',
-              },
-              {
-                label: 'Discord',
-                href: 'https://discord.gg/Wpk36QRdMN',
-              },
-              {
-                label: 'Twitter',
-                href: 'https://twitter.com/AragonProject/',
-              },
-            ],
-          },
-          {
-            title: 'More',
-            items: [
-              {
-                label: 'Blog',
-                to: 'https://blog.aragon.org/',
-              },
-              {
-                label: 'GitHub',
-                href: 'https://github.com/aragon',
-              },
-            ],
-          },
-        ],
-        copyright: `Copyright © ${new Date().getFullYear()} Aragon Association, Inc.`,
       },
       colorMode: {
         defaultMode: 'light',
@@ -193,7 +150,7 @@ const config = {
         rootPath: './versioned_docs/version-1.3.0',
         baseURL: 'osx/subgraph/reference-guide',
         homepage: './static/subgraph/index.md',
-        linkRoot: '/1.3.0',
+        linkRoot: '/docs',
         loaders: {
           JsonFileLoader: {
             module: '@graphql-tools/json-file-loader',

--- a/src/components/ComponentCard/index.tsx
+++ b/src/components/ComponentCard/index.tsx
@@ -1,0 +1,90 @@
+import {IconChevronRight} from '@aragon/ui-components';
+import React, {ReactNode} from 'react';
+import styled from 'styled-components';
+import {Link} from '@aragon/ui-components';
+import {useScreenSize} from '../../hooks/useScreenSize';
+export interface IComponentCardProps {
+  title: string;
+  description: string;
+  img: ReactNode;
+  to: string;
+  cta?: string;
+}
+type SvgContainerProps = {
+  isMobile: boolean;
+};
+
+export const ComponentCard = (props: IComponentCardProps) => {
+  const {isMobile} = useScreenSize();
+  const isInternal = props.to.startsWith('/');
+
+  return (
+    <A href={props.to} target={isInternal? "_self" : "_blank"} title={props.cta || 'Learn more'}>
+      <CardWrapper>
+        <SvgContainer isMobile={isMobile}>{props.img}</SvgContainer>
+        <ContentWrapper>
+          <TextWrapper>
+            <Title>{props.title}</Title>
+            <Description>{props.description}</Description>
+          </TextWrapper>
+        </ContentWrapper>
+      </CardWrapper>
+    </A>
+  );
+};
+
+const CardWrapper = styled.div.attrs({
+  className: 'flex flex-col md:flex-row rounded-xl border-2 border-neutral-50',
+})`
+  box-shadow: 0px 10px 20px rgba(31, 41, 51, 0.04),
+    0px 2px 6px rgba(31, 41, 51, 0.04), 0px 0px 1px rgba(31, 41, 51, 0.04);
+`;
+const ContentWrapper = styled.div.attrs({
+  className: 'flex flex-col space-y-3 md:py-8 p-6',
+})``;
+const TextWrapper = styled.div.attrs({
+  className: 'flex flex-col space-y-1',
+})``;
+const SvgContainer = styled.div.attrs({
+  className: 'flex rounded-xl',
+})`
+  svg {
+    width: ${getSvgSize};
+    height: ${getSvgSize};
+    border-radius: ${getSvgBorderRadius};
+  }
+`;
+const Title = styled.p.attrs({
+  className: 'text-xl font-bold',
+})`
+  color: var(--neutral-700);
+`;
+const Description = styled.p.attrs({
+  className: 'line-clamp-4 md:line-clamp-2',
+})`
+  color: var(--neutral-500);
+`;
+const Image = styled.img.attrs({
+  className: 'max-h-46',
+})`
+  object-fit: cover;
+`;
+const A = styled.a.attrs({
+  className: 'hover:no-underline',
+})`
+&:hover {
+  text-decoration: none !important;
+}
+`;
+function getSvgBorderRadius(props: SvgContainerProps) {
+  if (props.isMobile) {
+    return '8px 8px 0px 0px';
+  }
+  return '8px 0px 0px 8px';
+}
+function getSvgSize(props: SvgContainerProps) {
+  if (props.isMobile) {
+    return '100%';
+  }
+  return '';
+}

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -5,20 +5,12 @@ const currentYear = new Date().getFullYear();
 
 const leftLinks = [
   {
-    text: 'Home',
-    to: '/',
-  },
-  {
-    text: 'How it works',
-    to: '/docs/osx/how-it-works',
-  },
-  {
-    text: 'Guides',
-    to: '/docs/osx/how-to-guides',
-  },
-  {
-    text: 'Support',
+    text: 'Discord',
     to: 'https://discord.gg/Wpk36QRdMN',
+  },
+  {
+    text: 'Github',
+    to: 'https://github.com/aragon',
   }
 ];
 const rightLinks = [
@@ -26,14 +18,6 @@ const rightLinks = [
     text: 'Aragon',
     to: 'https://aragon.org',
   }
-  // {
-  //   text: 'Terms of service',
-  //   to: 'https://aragon.org',
-  // },
-  // {
-  //   text: 'Privacy',
-  //   to: 'https://aragon.org',
-  // },
 ];
 
 export const Footer = () => {
@@ -53,11 +37,10 @@ export const Footer = () => {
         <LinksContainer>
           {rightLinks.map((link, index) => (
             <Link href={link.to} key={index}>
-              {link.text}
+              {link.text} <Text>© {currentYear}</Text>
             </Link>
           ))}
         </LinksContainer>
-        <Text>© {currentYear}</Text>
       </RightContainer>
     </FooterWrapper>
   );

--- a/src/data/ComponentCards.tsx
+++ b/src/data/ComponentCards.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {IComponentCardProps} from '../components/ComponentCard';
+import {IllustrationOsx, IllustrationDesignSystem} from '../components';
+
+const componentCards: IComponentCardProps[] = [
+  {
+    title: 'Aragon OSx',
+    description:
+      'Secure, modular, and lean, the Aragon OSx protocol is your go-to DAO framework for building custom organizations on-chain.',
+    img: <IllustrationOsx />,
+    to: '/docs',
+  },
+  {
+    title: 'Design System',
+    description:
+      "Aragon's ODS is a human-centered, open-source design system powering designers and developers alike through a unified, builder-friendly framework.",
+    img: <IllustrationDesignSystem />,
+    to: 'https://github.com/aragon/apps/tree/develop/packages/ui-components',
+    cta: 'Coming soon',
+  },
+];
+export default componentCards;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Layout from '@theme/Layout';
+import styled from 'styled-components';
+import {HeroHeader} from '../components/HeroHeader';
+import {ComponentCard} from '../components/ComponentCard';
+import componentCards from '../data/ComponentCards';
+export default function Home(): JSX.Element {
+  return (
+    <Layout>
+      <Container>
+        <HeroHeader
+          title="Aragon Developer Portal"
+          subtitle="Here you'll find guides, resources, and references to build with the Aragon stack"
+          // eslint-disable-next-line @typescript-eslint/no-var-requires
+          img={require('@site/static/img/welcome-image.png').default}
+          imgAlt="Welcome to Aragon OSx"
+        />
+        <ComponentCardsWrapper>
+          <ComponentCardsTitle>Explore Products</ComponentCardsTitle>
+          {componentCards.map((card, index) => (
+            <ComponentCard
+              key={index}
+              title={card.title}
+              description={card.description}
+              img={card.img}
+              to={card.to}
+              cta={card.cta}
+            />
+          ))}
+        </ComponentCardsWrapper>
+      </Container>
+    </Layout>
+  );
+}
+const Container = styled.div.attrs({
+  className: 'md:p-18 p-6 flex-col flex space-y-12',
+})``;
+const ComponentCardsWrapper = styled.div.attrs({
+  className: 'flex flex-col space-y-6',
+})``;
+const ComponentCardsTitle = styled.p.attrs({
+  className: 'font-medium text-xl',
+})`
+  color: var(--neutral-700);
+`;

--- a/src/theme/NavbarItem/DocSidebarNavbarItem.js
+++ b/src/theme/NavbarItem/DocSidebarNavbarItem.js
@@ -20,8 +20,8 @@ export default function DocSidebarNavbarItem({
     );
   }
 
-  // Hide the navbar item if the pathname starts with 'docs/1.3.0'
-  if (pathname.startsWith('/1.3.0')) {
+  // Specify paths where the items should be hidden
+  if (pathname == '/' || pathname.includes('/1.3.0')) {
     return null;
   }
 

--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import OriginalDocsVersionDropdownNavbarItem from '@theme-original/NavbarItem/DocsVersionDropdownNavbarItem';
+import {useLocation} from '@docusaurus/router';
+
+export default function DocsVersionDropdownNavbarItem({...props}) {
+  const {pathname} = useLocation();
+
+  // Specify paths where the dropdown should be hidden
+  if (pathname == '/') {
+    return null;
+  }
+
+  return <OriginalDocsVersionDropdownNavbarItem {...props} />;
+}


### PR DESCRIPTION
## Description

This PR:
- restores the landing page
- set logic to manipulate the navbarItems based on path

we treat this PR as a POC, and also a checkpoint for all the work done on staging regarding 1.4

the plan forward is to not have the landing page, but on 1.3 create new sidebars for new products as ODS...etc, and in the future rework the structure of 1.4

Task: [ID]()
